### PR TITLE
Chrome/Firefox bookmark Import [WIP]

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -18,7 +18,7 @@ var config = {
         db: '',
         uploadDir: path.normalize('/var/data/anchr'),
         maxFileSize: 1000000 * 10,
-        allowedFileTypes: ['image/'],
+        allowedFileTypes: ['image/', 'text/html'],
         secret: 'shhh',
         tokenExpire: '30d',
         workers: 2,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "bcrypt-nodejs": "0.0.3",
         "body-parser": "1.13.3",
+        "bookmark-parser": "^0.1.5",
         "compression": "1.5.2",
         "connect-multiparty": "2.0.0",
         "express": "4.13.3",

--- a/public/app/views/collection.html
+++ b/public/app/views/collection.html
@@ -120,3 +120,62 @@
     </div>
 
 </div>
+
+<div class="content-box shadow-z-1">
+    <h3 class="text-primary">Import from Chrome/firefox bookmarks file.</h3>
+    <span class="text-secondary">Export bookmarks from Chrome/firefox into the .html file, and upload it here.</span>
+    <div class="row" ng-if="loggedIn()">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="file-drag" ngf-select="importBookmarks($file, $invalidFile)" ngf-drop="importBookmarks($file, $invalidFile)"
+                class="drop-box" ngf-drag-over-class="'dragover'" ngf-allow-dir="false" accept="text/html" ngf-pattern="'text/html'"
+                ngf-max-size="5MB">
+                Drop the bookmarks export file here, or click to upload.
+            </div>
+            <button class="btn btn-block btn-primary" ngf-select="importBookmarks($file, $invalidFile)" accept="text/html" ngf-max-size="5MB">
+                Select File
+            </button>
+            <div ng-show="data.file || data.errFile">
+                <div>
+                    <span ng-if="!data.file.finished && data.file.name">{{f.name}}</span>
+                    <div class="progress" ng-hide="data.file.finished || !data.file.name">
+                        <div class="progress-bar progress-bar-primary" style="width: {{data.file.progress}}%"></div>
+                    </div>
+                </div>
+
+                <!-- Successful upload -->
+                <div class="form-group no-space" ng-if="data.file.result">
+                    <div class="input-group">
+                        <span class="input-group-addon">
+                            <i class="mdi-action-done text-success"></i>
+                        </span>
+                        <span class="text-primary">
+                            File uploaded succesfully.
+                        </span>
+                    </div>
+                </div>
+
+                <!-- Unsucessful upload -->
+                <div class="form-group no-space" ng-if="data.file.err">
+                    <div class="input-group">
+                        <span class="input-group-addon">
+                            <i class="mdi-content-clear text-danger"></i>
+                        </span>
+                        <input type="text" class="form-control" value="{{data.file.name}} - {{data.file.err}}" disabled>
+                    </div>
+                </div>
+
+                <div class="form-group no-space" ng-if="data.errFile">
+                    <div class="input-group">
+                        <span class="input-group-addon">
+                            <i class="mdi-content-clear text-danger"></i>
+                        </span>
+                        <input type="text" class="form-control" value="{{data.errFile.name}} - {{data.errFile.$error}} {{data.errFile.$errorParam}}"
+                            disabled>
+                    </div>
+                </div>
+
+                <button class="btn btn-block" ng-click="clear()">Reset</button>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds the ability to let users import the bookmarks from Chrome and Firefox.

Work in progress.

Copied over from https://github.com/n1try/anchr/issues/2

- [x] Looks like you broke the table. Table header as well as description- and date column is gone (see http://prntscr.com/i4iezf)
- [ ] The import-related UI is too prominent. Instead of the whole drag & drop thing, I'd rather add a small icon + text (analogously to the + New button in the left bar), which directly opens a file picker. Roughly like this: http://prntscr.com/i4ii4m. You don't necessarily need to add a progress indicator in my opinion.
- [ ] Auto-reload collections after import is complete, so that the user gets feedback on success and immediately can see his bookmarks.
- [ ] I'd suggest to rather use [bookmarks-parser](https://www.npmjs.com/package/bookmarks-parser) (instead of [bookmark-parser](https://www.npmjs.com/package/bookmark-parser)) since it has fewer dependencies and doesn't require Python and stuff for compilation (which makes it easier to be installed especially on Windows)
- [ ] As you said, correctly handle corner cases and possible errors
- [x] Please also remove this comment: http://prntscr.com/i4ilhf